### PR TITLE
READMEで使用するSDKのブランチを一時的に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ export SAASUS_SECRET_KEY="xxxxxxxxxx"
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-pip install git+https://github.com/saasus-platform/saasus-sdk-python.git
+pip install git+https://github.com/saasus-platform/saasus-sdk-python.git@feature/v1
 sudo uvicorn main:app --port 80 --reload
 ```


### PR DESCRIPTION
SDKのv1ブランチを使うようにreadmeを修正

self_sign_upブランチからSDKのv1を使うようになっているため、

1. まず、本プルリクを `self_sign_up` ブランチにマージしてください。
2. その後、`self_sign_up` ブランチを `addition` ブランチにマージしてください。

