### PR TITLE
user_attribute_values の初期化をリストから辞書に修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ async def user_register(request: UserRegisterRequest, auth_user: dict = Depends(
 
         # ユーザー属性情報でnumber型が定義されている場合は、置換する
         if user_attribute_values is None:
-            user_attribute_values = []
+            user_attribute_values = {}
         else:
             user_attributes = user_attributes_obj.user_attributes
             for attribute in user_attributes:


### PR DESCRIPTION
user_attribute_values 変数の初期値を、他の箇所の実装に合わせて [] (リスト) から {} (辞書) に修正しました。